### PR TITLE
LDLFactorizations support

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -4,6 +4,7 @@ authors = ["Mathieu Tanneau <mathieu.tanneau@gmail.com>"]
 version = "0.1.1"
 
 [deps]
+LDLFactorizations = "40e66cde-538c-5869-a4ad-c39174c6795b"
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
 MathOptInterface = "b8f27783-ece8-5eb3-8dc8-9495eed66fee"
 OrderedCollections = "bac558e1-5e72-5ebc-8fee-abe8a469f55d"
@@ -12,6 +13,7 @@ SparseArrays = "2f01184e-e22b-5df5-ae63-d93ebab69eaf"
 SuiteSparse = "4607b0f0-06f3-5cda-b6b1-a6196a1729e9"
 
 [compat]
+LDLFactorizations = "^0.4"
 MathOptInterface = "~0.9.5"
 OrderedCollections = "1"
 julia = "1"

--- a/docs/src/man/linear_solvers.md
+++ b/docs/src/man/linear_solvers.md
@@ -48,11 +48,12 @@ One can pivot out the upper-left diagonal block to obtain the positive-definite
 
 Here is a list of currently supported linear solvers:
 
-| Linear solver type | type of ``A`` | System | Method | 
-|:--------------------|:------:|:--:|:--|
-| [`DenseLinearSolver`](@ref) | `Matrix` | Normal Eqn | Direct (Cholesky) |
-| [`SparseIndefLinearSolver`](@ref) | `SparseMatricCSC` | Augm. Sys | Direct (LDLt) |
-| [`SparsePosDefLinearSolver`](@ref) | `SparseMatricCSC` | Normal Eqn | Direct (Cholesky) |
+| Linear solver type | type of ``A`` | System | Method | Backend |
+|:--------------------|:------:|:--:|:--|:--|
+| [`DenseLinearSolver`](@ref) | `Matrix` | Normal Eqn | Direct (Cholesky) | LAPACK |
+| [`SparseIndefLinearSolver`](@ref) | `SparseMatricCSC` | Augm. Sys | Direct (LDLt) | SuiteSparse |
+| [`SparsePosDefLinearSolver`](@ref) | `SparseMatricCSC` | Normal Eqn | Direct (Cholesky) | SuiteSparse |
+| [`LDLFLinearSolver`](@ref) | `SparseMatricCSC` | Augm. Sys | Direct (LDLt) | [LDLFactorizations](https://github.com/JuliaSmoothOptimizers/LDLFactorizations.jl) |
 
 ### AbstractLinearSolver
 
@@ -117,4 +118,18 @@ update_linear_solver!(::SparsePosDefLinearSolver{Tv},::AbstractVector{Tv},::Abst
 
 ```@docs
 solve_augmented_system!(::Vector{Tv},::Vector{Tv},::SparsePosDefLinearSolver{Tv}, ::Vector{Tv}, ::Vector{Tv}) where{Tv<:BlasReal}
+```
+
+### LDLFLinearSolver
+
+```@docs
+LDLFLinearSolver
+```
+
+```@docs
+update_linear_solver!(::LDLFLinearSolver{Tv},::AbstractVector{Tv},::AbstractVector{Tv},::AbstractVector{Tv}) where{Tv<:Real}
+```
+
+```@docs
+solve_augmented_system!(::Vector{Tv},::Vector{Tv},::LDLFLinearSolver{Tv}, ::Vector{Tv}, ::Vector{Tv}) where{Tv<:Real}
 ```

--- a/src/LinearAlgebra/LinearSolvers/LDLF.jl
+++ b/src/LinearAlgebra/LinearSolvers/LDLF.jl
@@ -1,0 +1,122 @@
+import LDLFactorizations
+const LDLF = LDLFactorizations
+
+# ==============================================================================
+#   LDLFLinearSolver
+# ==============================================================================
+
+"""
+LDLFLinearSolver{Tv}
+
+Linear solver for the 2x2 augmented system with ``A`` sparse.
+
+Uses an LDLt factorization of the quasi-definite augmented system.
+"""
+mutable struct LDLFLinearSolver{Tv<:Real, Ta<:SparseMatrixCSC{Tv, <:Integer}} <: IndefLinearSolver{Tv, Ta}
+    m::Int  # Number of rows
+    n::Int  # Number of columns
+
+    # TODO: allow for user-provided ordering,
+    #   and add flag (default to false) to know whether user ordering should be used
+
+    # Problem data
+    A::Ta
+    θ::Vector{Tv}
+    regP::Vector{Tv}  # primal regularization
+    regD::Vector{Tv}  # dual regularization
+
+    # Factorization
+    F
+
+    # TODO: constructor with initial memory allocation
+    function LDLFLinearSolver(A::SparseMatrixCSC{Tv, Int}) where{Tv<:Real}
+        m, n = size(A)
+        θ = ones(Tv, n)
+
+        S = [
+            spdiagm(0 => -θ)  A';
+            A spdiagm(0 => ones(m))
+        ]
+
+        # TODO: PSD-ness checks
+        F = LDLF.ldl(S)
+        return new{Tv, SparseMatrixCSC{Tv, Int}}(m, n, A, θ, ones(Tv, n), ones(Tv, m), F)
+    end
+
+end
+
+"""
+    update_linear_solver!(ls, θ, regP, regD)
+
+Update LDLt factorization of the augmented system.
+
+Update diagonal scaling ``\\theta``, primal-dual regularizations, and re-compute
+    the factorization.
+Throws a `PosDefException` if matrix is not quasi-definite.
+"""
+function update_linear_solver!(
+    ls::LDLFLinearSolver{Tv, Ta},
+    θ::AbstractVector{Tv},
+    regP::AbstractVector{Tv},
+    regD::AbstractVector{Tv}
+) where{Tv<:Real, Ta<:AbstractMatrix{Tv}}
+    # Sanity checks
+    length(θ)  == ls.n || throw(DimensionMismatch(
+        "θ has length $(length(θ)) but linear solver is for n=$(ls.n)."
+    ))
+    length(regP) == ls.n || throw(DimensionMismatch(
+        "regP has length $(length(regP)) but linear solver has n=$(ls.n)"
+    ))
+    length(regD) == ls.m || throw(DimensionMismatch(
+        "regD has length $(length(regD)) but linear solver has m=$(ls.m)"
+    ))
+
+    # Update diagonal scaling
+    ls.θ .= θ
+    # Update regularizers
+    ls.regP .= regP
+    ls.regD .= regD
+
+    # Re-compute factorization
+    # TODO: Keep S in memory, only change diagonal
+    S = [
+        spdiagm(0 => -ls.θ .- regP)  ls.A';
+        ls.A spdiagm(0 => regD)
+    ]
+
+    # TODO: PSD-ness checks
+    ls.F = LDLF.ldl(S)
+
+    return nothing
+end
+
+"""
+    solve_augmented_system!(dx, dy, ls, ξp, ξd)
+
+Solve the augmented system, overwriting `dx, dy` with the result.
+
+# Arguments
+- `dx, dy`: Vectors of unknowns, modified in-place
+- `ls::SparseIndefLinearSolver`: Linear solver for the augmented system
+- `ξp, ξd`: Right-hand-side vectors
+"""
+function solve_augmented_system!(
+    dx::Vector{Tv}, dy::Vector{Tv},
+    ls::LDLFLinearSolver{Tv},
+    ξp::Vector{Tv}, ξd::Vector{Tv}
+) where{Tv<:Real}
+    m, n = ls.m, ls.n
+    
+    # Set-up right-hand side
+    ξ = [ξd; ξp]
+
+    # Solve augmented system
+    d = ls.F \ ξ
+
+    # Recover dx, dy
+    @views dx .= d[1:n]
+    @views dy .= d[(n+1):(m+n)]
+
+    # TODO: Iterative refinement
+    return nothing
+end

--- a/src/LinearAlgebra/LinearSolvers/LDLF.jl
+++ b/src/LinearAlgebra/LinearSolvers/LDLF.jl
@@ -6,7 +6,7 @@ const LDLF = LDLFactorizations
 # ==============================================================================
 
 """
-LDLFLinearSolver{Tv}
+    LDLFLinearSolver{Tv}
 
 Linear solver for the 2x2 augmented system with ``A`` sparse.
 
@@ -26,7 +26,7 @@ mutable struct LDLFLinearSolver{Tv<:Real, Ta<:SparseMatrixCSC{Tv, <:Integer}} <:
     regD::Vector{Tv}  # dual regularization
 
     # Factorization
-    F
+    F::LDLF.LDLFactorization{Tv}
 
     # TODO: constructor with initial memory allocation
     function LDLFLinearSolver(A::SparseMatrixCSC{Tv, Int}) where{Tv<:Real}

--- a/src/LinearAlgebra/LinearSolvers/LinearSolvers.jl
+++ b/src/LinearAlgebra/LinearSolvers/LinearSolvers.jl
@@ -65,9 +65,13 @@ function solve_augmented_system! end
 # 
 include("dense.jl")
 include("sparse.jl")
+include("LDLF.jl")
 
 # TODO: use parameter to choose between Indef/PosDef system
 AbstractLinearSolver(A::Matrix{Tv}) where{Tv<:Real} = DenseLinearSolver(A)
 AbstractLinearSolver(
     A::SparseMatrixCSC{Tv, Int64}
 ) where{Tv<:BlasReal} = SparseIndefLinearSolver(A)
+AbstractLinearSolver(
+    A::SparseMatrixCSC{Tv, Int64}
+) where{Tv<:Real} = LDLFLinearSolver(A)


### PR DESCRIPTION
Adds support for [LDLFactorizations.jl](https://github.com/JuliaSmoothOptimizers/LDLFactorizations.jl) as a backend for linear solvers.

This is the default choice for sparse matrices whose numerical precision cannot be handled by SuiteSparse, i.e., anything other than Float32/Float64.