### PR TITLE
Initial infrastructure for Krylov-based linear solvers

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -4,6 +4,7 @@ authors = ["Mathieu Tanneau <mathieu.tanneau@gmail.com>"]
 version = "0.5.1"
 
 [deps]
+Krylov = "ba0b0d4f-ebba-5204-a429-3ac8c609bfb7"
 LDLFactorizations = "40e66cde-538c-5869-a4ad-c39174c6795b"
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
 Logging = "56ddb016-857b-54e1-b83d-db4d58db5568"

--- a/Project.toml
+++ b/Project.toml
@@ -16,6 +16,7 @@ SuiteSparse = "4607b0f0-06f3-5cda-b6b1-a6196a1729e9"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [compat]
+Krylov = "0.5.2"
 LDLFactorizations = "^0.5"
 MathOptInterface = "~0.9.5"
 QPSReader = "0.2"

--- a/docs/src/manual/linear_systems.md
+++ b/docs/src/manual/linear_systems.md
@@ -53,5 +53,10 @@ Here is a list of currently supported linear solvers:
 | [`Cholmod_SymQuasDef`](@ref) | `Float64` | Augmented system | CHOLMOD | LDLᵀ
 | [`Cholmod_SymPosDef`](@ref) | `Float64` | Normal equations | CHOLMOD | Cholesky
 | [`LDLFact_SymQuasDef`](@ref) | `Real` | Augmented system | [LDLFactorizations.jl](https://github.com/JuliaSmoothOptimizers/LDLFactorizations.jl) | LDLᵀ
-| [`KrylovPDSolver`](@ref) | `Real` | Normal equations | [Krylov.jl](https://github.com/JuliaSmoothOptimizers/Krylov.jl) | Krylov
-| [`KrylovSQDSolver`](@ref) | `Real` | Augmented system | [Krylov.jl](https://github.com/JuliaSmoothOptimizers/Krylov.jl) | Krylov
+| [`KrylovSPDSolver`](@ref) | `Real` | Normal equations | [Krylov.jl](https://github.com/JuliaSmoothOptimizers/Krylov.jl) | Krylov
+| [`KrylovSIDSolver`](@ref) | `Real` | Augmented system[^1] | [Krylov.jl](https://github.com/JuliaSmoothOptimizers/Krylov.jl) | Krylov
+| [`KrylovSQDSolver`](@ref) | `Real` | Augmented system[^1] | [Krylov.jl](https://github.com/JuliaSmoothOptimizers/Krylov.jl) | Krylov
+
+[^1]: [`KrylovSIDSolver`](@ref)s view the augmented system as a symmetric indefinite system,
+    while [`KrylovSQDSolver`](@ref)s exploit its 2x2 structure and quasi-definite property.
+    See the reference documentation for more details.

--- a/docs/src/manual/linear_systems.md
+++ b/docs/src/manual/linear_systems.md
@@ -38,7 +38,7 @@ The augmented system above can be reduced to the positive-definite _normal equat
 \Delta x &= (Θ^{-1} + R_{p})^{-1} (A^{T} \Delta y - \xi_{d})
 \end{array}
 ```
-When selected, this reduction is transparent to the interior-point algorithm.
+If available and when selected, this reduction is transparent to the interior-point algorithm.
 
 To enable the use of fast external libraries and/or specialized routines, the resolution of linear systems is performed by an [`AbstractKKTSolver`] object.
 
@@ -53,3 +53,5 @@ Here is a list of currently supported linear solvers:
 | [`Cholmod_SymQuasDef`](@ref) | `Float64` | Augmented system | CHOLMOD | LDLᵀ
 | [`Cholmod_SymPosDef`](@ref) | `Float64` | Normal equations | CHOLMOD | Cholesky
 | [`LDLFact_SymQuasDef`](@ref) | `Real` | Augmented system | [LDLFactorizations.jl](https://github.com/JuliaSmoothOptimizers/LDLFactorizations.jl) | LDLᵀ
+| [`KrylovPDSolver`](@ref) | `Real` | Normal equations | [Krylov.jl](https://github.com/JuliaSmoothOptimizers/Krylov.jl) | Krylov
+| [`KrylovSQDSolver`](@ref) | `Real` | Augmented system | [Krylov.jl](https://github.com/JuliaSmoothOptimizers/Krylov.jl) | Krylov

--- a/docs/src/reference/kkt_solvers.md
+++ b/docs/src/reference/kkt_solvers.md
@@ -66,3 +66,18 @@ Cholmod_SymPosDef
 ```@docs
 LDLFact_SymQuasDef
 ```
+
+## Krylov
+
+!!! warning
+    Iterative methods are still an experimental feature.
+    Some numerical and performance issues should be expected.
+
+
+```@docs
+KrylovPDSolver
+```
+
+```@docs
+KrylovSQDSolver
+```

--- a/docs/src/reference/kkt_solvers.md
+++ b/docs/src/reference/kkt_solvers.md
@@ -75,7 +75,11 @@ LDLFact_SymQuasDef
 
 
 ```@docs
-KrylovPDSolver
+KrylovSPDSolver
+```
+
+```@docs
+KrylovSIDSolver
 ```
 
 ```@docs

--- a/src/KKTSolver/KKTSolver.jl
+++ b/src/KKTSolver/KKTSolver.jl
@@ -107,6 +107,7 @@ include("test.jl")
 include("lapack.jl")
 include("cholmod.jl")
 include("ldlfact.jl")
+include("krylov.jl")
 
 """
     default_options(Tv)

--- a/src/KKTSolver/krylov.jl
+++ b/src/KKTSolver/krylov.jl
@@ -93,14 +93,14 @@ function solve!(
 
     # Setup
     d = one(Float64) ./ (kkt.θ .+ kkt.regP)
-    D = LO.opDiagonal(d)
+    D = Diagonal(d)
     
     # Set-up right-hand side
     ξ_ = ξp .+ kkt.A * (D * ξd)
 
     # Solve normal equations
     opA = LO.LinearOperator(kkt.A)
-    opS = opA * D * opA' + LO.opDiagonal(kkt.regD)
+    opS = opA * D * opA' + Diagonal(kkt.regD)
     y, stats = kkt.f(opS, ξ_)
 
     # @info stats.residuals
@@ -203,7 +203,7 @@ function solve!(
 
     # Setup
     d = one(Float64) ./ (kkt.θ .+ kkt.regP)
-    D = LO.opDiagonal(d)
+    D = Diagonal(d)
 
     # Solve augmented system
     # Currently assumes that Rd is a multiple of the identity matrix

--- a/src/KKTSolver/krylov.jl
+++ b/src/KKTSolver/krylov.jl
@@ -93,7 +93,7 @@ function solve!(
     m, n = kkt.m, kkt.n
 
     # Setup
-    d = one(Float64) ./ (kkt.θ .+ kkt.regP)
+    d = one(Tv) ./ (kkt.θ .+ kkt.regP)
     D = Diagonal(d)
     
     # Set-up right-hand side
@@ -213,7 +213,7 @@ function solve!(
     m, n = kkt.m, kkt.n
 
     # Setup
-    d = one(Float64) ./ (kkt.θ .+ kkt.regP)
+    d = one(Tv) ./ (kkt.θ .+ kkt.regP)
     D = Diagonal(d)
 
     # Solve augmented system

--- a/src/KKTSolver/krylov.jl
+++ b/src/KKTSolver/krylov.jl
@@ -1,10 +1,15 @@
 import Krylov
 const LO = Krylov.LinearOperators
 
-abstract type KrylovSolver{T} <: AbstractKKTSolver{T} end
+"""
+    AbstractKrylovSolver{T}
+
+Abstract type for Kyrlov-based linear solvers.
+"""
+abstract type AbstractKrylovSolver{T} <: AbstractKKTSolver{T} end
 
 # ==============================================================================
-#   KrylovPDSolver: 
+#   KrylovPDSolver:
 # ==============================================================================
 
 """
@@ -18,7 +23,7 @@ model.params.KKTOptions = Tulip.KKT.SolverOptions(
 )
 ```
 """
-mutable struct KrylovPDSolver{T, F, Tv, Ta} <: KrylovSolver{T}
+mutable struct KrylovPDSolver{T, F, Tv, Ta} <: AbstractKrylovSolver{T}
     m::Int
     n::Int
 
@@ -129,6 +134,150 @@ end
 
 
 # ==============================================================================
+#   KrylovSIDSolver:
+# ==============================================================================
+
+"""
+    KrylovSIDSolver{T, F, Tv, Ta}
+
+Solves the augmented system with an iterative method `f::F`.
+
+The Krylov method should not exploit the system's SQD structure explicitly,
+and the function `f` will be called as:
+```julia
+Δ, _ = f(K, ξ; atol, rtol)
+```
+where `K` and `ξ` are the is the 2x2 system's
+left-hand side matrix (or a suitable linear operator)
+and right-hand side, respectively, and
+`Δ` is the solution vector.
+
+```julia
+model.params.KKTOptions = Tulip.KKT.SolverOptions(
+    KrylovSIDSolver, method=Krylov.minres
+)
+```
+"""
+mutable struct KrylovSIDSolver{T, F, Tv, Ta} <: AbstractKrylovSolver{T}
+    m::Int
+    n::Int
+
+    f::F     # Krylov function
+    atol::T  # absolute tolerance
+    rtol::T  # relative tolerance
+
+    # Problem data
+    A::Ta     # Constraint matrix
+    θ::Tv     # scaling
+    regP::Tv  # primal regularization
+    regD::Tv  # dual regularization
+
+    function KrylovSIDSolver(f::Function, A::Ta;
+        atol::T=sqrt(eps(T)),
+        rtol::T=sqrt(eps(T))
+    ) where{T, Ta <: AbstractMatrix{T}}
+        F = typeof(f)
+        m, n = size(A)
+
+        return new{T, F, Vector{T}, Ta}(
+            m, n,
+            f, atol, rtol,
+            A, ones(T, n), ones(T, n), ones(T, m)
+        )
+    end
+end
+
+setup(::Type{KrylovSIDSolver}, A; method, kwargs...) = KrylovSIDSolver(method, A; kwargs...)
+
+backend(kkt::KrylovSIDSolver) = "Krylov ($(kkt.f))"
+linear_system(::KrylovSIDSolver) = "Augmented system"
+
+
+"""
+    update!(kkt::KrylovSIDSolver, θ, regP, regD)
+
+Update diagonal scaling ``θ`` and primal-dual regularizations.
+"""
+function update!(
+    kkt::KrylovSIDSolver{Tv},
+    θ::AbstractVector{Tv},
+    regP::AbstractVector{Tv},
+    regD::AbstractVector{Tv}
+) where{Tv<:Real}
+    # Sanity checks
+    length(θ)  == kkt.n || throw(DimensionMismatch(
+        "θ has length $(length(θ)) but linear solver is for n=$(kkt.n)."
+    ))
+    length(regP) == kkt.n || throw(DimensionMismatch(
+        "regP has length $(length(regP)) but linear solver has n=$(kkt.n)"
+    ))
+    length(regD) == kkt.m || throw(DimensionMismatch(
+        "regD has length $(length(regD)) but linear solver has m=$(kkt.m)"
+    ))
+
+    # Update diagonal scaling
+    kkt.θ .= θ
+    # Update regularizers
+    kkt.regP .= regP
+    kkt.regD .= regD
+
+    return nothing
+end
+
+"""
+    solve!(dx, dy, kkt::KrylovSIDSolver, ξp, ξd)
+
+Solve the normal equations system using an iterative method.
+"""
+function solve!(
+    dx::Vector{Tv}, dy::Vector{Tv},
+    kkt::KrylovSIDSolver{Tv},
+    ξp::Vector{Tv}, ξd::Vector{Tv}
+) where{Tv<:Real}
+    m, n = kkt.m, kkt.n
+
+    # Setup
+    A = kkt.A
+    D = Diagonal(-(kkt.θ .+ kkt.regP))  # D = Θ⁻¹ + Rp
+
+    # Set-up right-hand side
+    ξ = [ξd; ξp]
+
+    # Form linear operator K = [-(Θ⁻¹ + Rp) Aᵀ; A Rd]
+    # Here we pre-allocate the final vector
+    z = zeros(Tv, m+n)
+    opK = LO.LinearOperator(Tv, n+m, n+m, true, false,
+        w -> begin
+            @views z1 = z[1:n]
+            @views z2 = z[n+1:n+m]
+
+            @views w1 = w[1:n]
+            @views w2 = w[n+1:n+m]
+
+            # z1 = -(Θ⁻¹ + Rp) w1 + A'w2
+            mul!(z1, D, w1, one(Tv), zero(Tv))  # z1 = -(Θ⁻¹ + Rp) w1
+            mul!(z1, A', w2, one(Tv), one(Tv))  # z1 += A'w2
+
+            # z2 = A w1 + Rd w2
+            mul!(z2, A, w1, one(Tv), zero(Tv))   # z2 = A w1
+            mul!(z2, Diagonal(kkt.regD), w2, one(Tv), one(Tv))  # z2 += Rd * w2
+
+            z
+        end
+    )
+
+    # Solve augmented system
+    Δ, stats = kkt.f(opK, ξ, atol=kkt.atol, rtol=kkt.rtol)
+
+    # Recover dx, dy
+    dx .= Δ[1:n]
+    dy .= Δ[n+1:n+m]
+
+    return nothing
+end
+
+
+# ==============================================================================
 #   KrylovSQDSolver: 
 # ==============================================================================
 
@@ -143,7 +292,7 @@ model.params.KKTOptions = Tulip.KKT.SolverOptions(
 )
 ```
 """
-mutable struct KrylovSQDSolver{T, F, Tv, Ta} <: KrylovSolver{T}
+mutable struct KrylovSQDSolver{T, F, Tv, Ta} <: AbstractKrylovSolver{T}
     m::Int
     n::Int
     

--- a/src/KKTSolver/krylov.jl
+++ b/src/KKTSolver/krylov.jl
@@ -1,5 +1,4 @@
 import Krylov
-# import LinearOperators
 const LO = Krylov.LinearOperators
 
 abstract type KrylovSolver{T} <: AbstractKKTSolver{T} end
@@ -109,6 +108,110 @@ function solve!(
 
     # Recover dx
     dx .= D * (kkt.A' * dy - ξd)
+
+    return nothing
+end
+
+
+# ==============================================================================
+#   KrylovSQDSolver: 
+# ==============================================================================
+
+"""
+    KrylovSQDSolver{T, F, Tv, Ta}
+
+Solves the augmented system with an iterative method `f::F`.
+
+```julia
+model.params.KKTOptions = Tulip.KKT.SolverOptions(
+    KrylovSQDSolver, method=Krylov.trimr
+)
+```
+"""
+mutable struct KrylovSQDSolver{T, F, Tv, Ta} <: KrylovSolver{T}
+    m::Int
+    n::Int
+
+    f::F
+
+    # Problem data
+    A::Ta     # Constraint matrix
+    θ::Tv     # scaling
+    regP::Tv  # primal regularization
+    regD::Tv  # dual regularization
+
+    function KrylovSQDSolver(f::Function, A::Ta) where{Ta <: AbstractMatrix}
+        F = typeof(f)
+        m, n = size(A)
+        T = eltype(A)
+        return new{T, F, Vector{T}, Ta}(
+            m, n,
+            f,
+            A, ones(T, n), ones(T, n), ones(T, m)
+        )
+    end
+end
+
+setup(::Type{KrylovSQDSolver}, A; method=Krylov.trimr) = KrylovSQDSolver(method, A)
+
+backend(kkt::KrylovSQDSolver) = "Krylov ($(kkt.f))"
+linear_system(::KrylovSQDSolver) = "Augmented system"
+
+
+"""
+    update!(kkt::KrylovSQDSolver, θ, regP, regD)
+
+Update diagonal scaling ``θ`` and primal-dual regularizations.
+"""
+function update!(
+    kkt::KrylovSQDSolver{Tv},
+    θ::AbstractVector{Tv},
+    regP::AbstractVector{Tv},
+    regD::AbstractVector{Tv}
+) where{Tv<:Real}
+    # Sanity checks
+    length(θ)  == kkt.n || throw(DimensionMismatch(
+        "θ has length $(length(θ)) but linear solver is for n=$(kkt.n)."
+    ))
+    length(regP) == kkt.n || throw(DimensionMismatch(
+        "regP has length $(length(regP)) but linear solver has n=$(kkt.n)"
+    ))
+    length(regD) == kkt.m || throw(DimensionMismatch(
+        "regD has length $(length(regD)) but linear solver has m=$(kkt.m)"
+    ))
+
+    # Update diagonal scaling
+    kkt.θ .= θ
+    # Update regularizers
+    kkt.regP .= regP
+    kkt.regD .= regD
+
+    return nothing
+end
+
+"""
+    solve!(dx, dy, kkt::KrylovSQDSolver, ξp, ξd)
+
+Solve the normal equations system using an iterative method.
+"""
+function solve!(
+    dx::Vector{Tv}, dy::Vector{Tv},
+    kkt::KrylovSQDSolver{Tv},
+    ξp::Vector{Tv}, ξd::Vector{Tv}
+) where{Tv<:Real}
+    m, n = kkt.m, kkt.n
+
+    # Setup
+    d = one(Float64) ./ (kkt.θ .+ kkt.regP)
+    D = LO.opDiagonal(d)
+
+    # Solve augmented system
+    # Currently assumes that Rd is a multiple of the identity matrix
+    _dy, _dx, stats = kkt.f(kkt.A, ξp, ξd, N=D, τ = kkt.regD[1])
+
+    # @info stats.residuals
+    dx .= _dx
+    dy .= _dy
 
     return nothing
 end

--- a/src/KKTSolver/krylov.jl
+++ b/src/KKTSolver/krylov.jl
@@ -1,0 +1,114 @@
+import Krylov
+# import LinearOperators
+const LO = Krylov.LinearOperators
+
+abstract type KrylovSolver{T} <: AbstractKKTSolver{T} end
+
+# ==============================================================================
+#   KrylovPDSolver: 
+# ==============================================================================
+
+"""
+    KrylovPDSolver{T, F, Tv, Ta}
+
+Solves normal equations system with an iterative method `f::F`.
+
+```julia
+model.params.KKTOptions = Tulip.KKT.SolverOptions(
+    KrylovPDSolver, method=Krylov.cg
+)
+```
+"""
+mutable struct KrylovPDSolver{T, F, Tv, Ta} <: KrylovSolver{T}
+    m::Int
+    n::Int
+
+    f::F
+
+    # Problem data
+    A::Ta     # Constraint matrix
+    θ::Tv     # scaling
+    regP::Tv  # primal regularization
+    regD::Tv  # dual regularization
+
+    function KrylovPDSolver(f::Function, A::Ta) where{Ta <: AbstractMatrix}
+        F = typeof(f)
+        m, n = size(A)
+        T = eltype(A)
+        return new{T, F, Vector{T}, Ta}(
+            m, n,
+            f,
+            A, ones(T, n), ones(T, n), ones(T, m)
+        )
+    end
+end
+
+setup(::Type{KrylovPDSolver}, A; method) = KrylovPDSolver(method, A)
+
+backend(kkt::KrylovPDSolver) = "Krylov ($(kkt.f))"
+linear_system(::KrylovPDSolver) = "Normal equations"
+
+
+"""
+    update!(kkt::KrylovPDSolver, θ, regP, regD)
+
+Update diagonal scaling ``θ`` and primal-dual regularizations.
+"""
+function update!(
+    kkt::KrylovPDSolver{Tv},
+    θ::AbstractVector{Tv},
+    regP::AbstractVector{Tv},
+    regD::AbstractVector{Tv}
+) where{Tv<:Real}
+    # Sanity checks
+    length(θ)  == kkt.n || throw(DimensionMismatch(
+        "θ has length $(length(θ)) but linear solver is for n=$(kkt.n)."
+    ))
+    length(regP) == kkt.n || throw(DimensionMismatch(
+        "regP has length $(length(regP)) but linear solver has n=$(kkt.n)"
+    ))
+    length(regD) == kkt.m || throw(DimensionMismatch(
+        "regD has length $(length(regD)) but linear solver has m=$(kkt.m)"
+    ))
+
+    # Update diagonal scaling
+    kkt.θ .= θ
+    # Update regularizers
+    kkt.regP .= regP
+    kkt.regD .= regD
+
+    return nothing
+end
+
+"""
+    solve!(dx, dy, kkt::KrylovPDSolver, ξp, ξd)
+
+Solve the normal equations system using an iterative method.
+"""
+function solve!(
+    dx::Vector{Tv}, dy::Vector{Tv},
+    kkt::KrylovPDSolver{Tv},
+    ξp::Vector{Tv}, ξd::Vector{Tv}
+) where{Tv<:Real}
+    m, n = kkt.m, kkt.n
+
+    # Setup
+    d = one(Float64) ./ (kkt.θ .+ kkt.regP)
+    D = LO.opDiagonal(d)
+    
+    # Set-up right-hand side
+    ξ_ = ξp .+ kkt.A * (D * ξd)
+
+    # Solve normal equations
+    opA = LO.LinearOperator(kkt.A)
+    opS = opA * D * opA' + LO.opDiagonal(kkt.regD)
+    y, stats = kkt.f(opS, ξ_)
+
+    # @info stats.residuals
+    dy .= y
+
+    # Recover dx
+    dx .= D * (kkt.A' * dy - ξd)
+
+    return nothing
+end

--- a/src/KKTSolver/krylov.jl
+++ b/src/KKTSolver/krylov.jl
@@ -410,12 +410,13 @@ function solve!(
 
     # Setup
     d = one(Tv) ./ (kkt.θ .+ kkt.regP)
-    D = Diagonal(d)
+    N = Diagonal(d)
+
+    M = Diagonal(one(Tv) ./ kkt.regD)
 
     # Solve augmented system
-    # Currently assumes that Rd is a multiple of the identity matrix
     _dy, _dx, stats = kkt.f(kkt.A, ξp, ξd,
-        N=D, τ = kkt.regD[1],
+        M=M, N=N,
         atol=kkt.atol, rtol=kkt.rtol
     )
 

--- a/src/KKTSolver/krylov.jl
+++ b/src/KKTSolver/krylov.jl
@@ -53,8 +53,8 @@ mutable struct KrylovSPDSolver{T, F, Tv, Ta} <: AbstractKrylovSolver{T}
     regD::Tv  # dual regularization
 
     function KrylovSPDSolver(f::Function, A::Ta;
-        atol::T=sqrt(eps(T)),
-        rtol::T=sqrt(eps(T))
+        atol::T=eps(T)^(3 // 4),
+        rtol::T=eps(T)^(3 // 4)
     ) where{T, Ta <: AbstractMatrix{T}}
         F = typeof(f)
         m, n = size(A)
@@ -193,8 +193,8 @@ mutable struct KrylovSIDSolver{T, F, Tv, Ta} <: AbstractKrylovSolver{T}
     regD::Tv  # dual regularization
 
     function KrylovSIDSolver(f::Function, A::Ta;
-        atol::T=sqrt(eps(T)),
-        rtol::T=sqrt(eps(T))
+        atol::T=eps(T)^(3 // 4),
+        rtol::T=eps(T)^(3 // 4)
     ) where{T, Ta <: AbstractMatrix{T}}
         F = typeof(f)
         m, n = size(A)
@@ -345,8 +345,8 @@ mutable struct KrylovSQDSolver{T, F, Tv, Ta} <: AbstractKrylovSolver{T}
     regD::Tv  # dual regularization
 
     function KrylovSQDSolver(f::Function, A::Ta;
-        atol::T=sqrt(eps(T)),
-        rtol::T=sqrt(eps(T))
+        atol::T=eps(T)^(3 // 4),
+        rtol::T=eps(T)^(3 // 4)
     ) where{T, Ta <: AbstractMatrix{T}}
         F = typeof(f)
         m, n = size(A)

--- a/test/KKTSolver/KKTSolver.jl
+++ b/test/KKTSolver/KKTSolver.jl
@@ -3,3 +3,4 @@ const KKT = Tulip.KKT
 include("lapack.jl")
 include("cholmod.jl")
 include("ldlfact.jl")
+include("krylov.jl")

--- a/test/KKTSolver/krylov.jl
+++ b/test/KKTSolver/krylov.jl
@@ -1,14 +1,28 @@
 import Krylov
 
 @testset "Krylov" begin
-    for T in TvTYPES, f in [Krylov.cg, Krylov.minres]
-        @testset "$f, $T" begin
-            A = SparseMatrixCSC{T, Int}([
-                1 0 1 0;
-                0 1 0 1
-            ])
-            kkt = KKT.KrylovPDSolver(f, A)
-            KKT.run_ls_tests(A, kkt)
+    for T in TvTYPES
+        @testset "$T" begin
+            for f in [Krylov.cg, Krylov.minres, Krylov.minres_qlp]
+                @testset "$f" begin
+                    A = SparseMatrixCSC{T, Int}([
+                        1 0 1 0;
+                        0 1 0 1
+                    ])
+                    kkt = KKT.KrylovPDSolver(f, A)
+                    KKT.run_ls_tests(A, kkt)
+                end
+            end
+            for f in [Krylov.tricg, Krylov.trimr]
+                @testset "$f" begin
+                    A = SparseMatrixCSC{T, Int}([
+                        1 0 1 0;
+                        0 1 0 1
+                    ])
+                    kkt = KKT.KrylovSQDSolver(f, A)
+                    KKT.run_ls_tests(A, kkt)
+                end
+            end
         end
     end
 end

--- a/test/KKTSolver/krylov.jl
+++ b/test/KKTSolver/krylov.jl
@@ -10,7 +10,7 @@ import Krylov
                         1 0 1 0;
                         0 1 0 1
                     ])
-                    kkt = KKT.KrylovPDSolver(f, A)
+                    kkt = KKT.KrylovSPDSolver(f, A)
                     KKT.run_ls_tests(A, kkt)
                 end
             end

--- a/test/KKTSolver/krylov.jl
+++ b/test/KKTSolver/krylov.jl
@@ -3,8 +3,9 @@ import Krylov
 @testset "Krylov" begin
     for T in TvTYPES
         @testset "$T" begin
+            # Kyrlov solvers for symmetric positive-definite systems
             for f in [Krylov.cg, Krylov.minres, Krylov.minres_qlp]
-                @testset "$f" begin
+                @testset "PD:  $f" begin
                     A = SparseMatrixCSC{T, Int}([
                         1 0 1 0;
                         0 1 0 1
@@ -13,8 +14,20 @@ import Krylov
                     KKT.run_ls_tests(A, kkt)
                 end
             end
+            # Kyrlov solvers for symmetric indefinite systems
+            for f in [Krylov.minres, Krylov.minres_qlp]
+                @testset "SID: $f" begin
+                    A = SparseMatrixCSC{T, Int}([
+                        1 0 1 0;
+                        0 1 0 1
+                    ])
+                    kkt = KKT.KrylovSIDSolver(f, A)
+                    KKT.run_ls_tests(A, kkt)
+                end
+            end
+            # Kyrlov solvers for symmetric quasi-definite systems
             for f in [Krylov.tricg, Krylov.trimr]
-                @testset "$f" begin
+                @testset "SQD: $f" begin
                     A = SparseMatrixCSC{T, Int}([
                         1 0 1 0;
                         0 1 0 1

--- a/test/KKTSolver/krylov.jl
+++ b/test/KKTSolver/krylov.jl
@@ -1,0 +1,14 @@
+import Krylov
+
+@testset "Krylov" begin
+    for T in TvTYPES, f in [Krylov.cg, Krylov.minres]
+        @testset "$f, $T" begin
+            A = SparseMatrixCSC{T, Int}([
+                1 0 1 0;
+                0 1 0 1
+            ])
+            kkt = KKT.KrylovPDSolver(f, A)
+            KKT.run_ls_tests(A, kkt)
+        end
+    end
+end


### PR DESCRIPTION
cc @amontoison

This PR introduces some infrastructure for Krylov-based linear solvers.
There are no Krylov-specific algorithmic modifications to the IPM at this point.

TODO:
* [x] Identify relevant data structures and interfaces for the task
* [x] ~Decide on how to best implement preconditioners~ [left for future PR]
* [x] Add unit tests
* [x] Update docs

Currently, a Krylov solver can be selected as follows:
```julia
model.params.KKTOptions = Tulip.KKT.SolverOptions(
    Tulip.KKT.KrylovPDSolver,       # Solve the normal equations system with a Krylov method
    method=Tulip.KKT.Krylov.minres  # Select the Krylov method
)
```
the syntax also allows for passing a callback:
```julia
model.params.KKTOptions = Tulip.KKT.SolverOptions(
    Tulip.KKT.KrylovPDSolver,       # Solve the normal equations system with a Krylov method
    method=(A, b) -> Tulip.KKT.Krylov.cg(A, b)  # "custom" Krylov method
)
```