### PR TITLE
Fix compat of Convex.jl in tests

### DIFF
--- a/test/Project.toml
+++ b/test/Project.toml
@@ -6,3 +6,6 @@ MathOptInterface = "b8f27783-ece8-5eb3-8dc8-9495eed66fee"
 SparseArrays = "2f01184e-e22b-5df5-ae63-d93ebab69eaf"
 TOML = "fa267f1f-6049-4f14-aa54-33bafae1ed76"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
+
+[compat]
+Convex = "0.14"


### PR DESCRIPTION
No compat was causing Pkg to install an earlier version in tests with `MOI#master` for some reason.