### PR TITLE
Hotfix for the next release of Krylov.jl

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -22,7 +22,7 @@ TimerOutputs = "a759f4b9-e2f1-59dc-863e-4aeb61b1ea8f"
 [compat]
 CodecBzip2 = "0.7.2"
 CodecZlib = "0.7.0"
-Krylov = "0.7.3"
+Krylov = "0.7.7"
 LDLFactorizations = "0.6, 0.7, 0.8"
 LinearOperators = "2.0"
 MathOptInterface = "0.9.5"

--- a/src/KKT/Krylov/sqd.jl
+++ b/src/KKT/Krylov/sqd.jl
@@ -92,8 +92,8 @@ function solve!(dx, dy, kkt::SQDSolver{T}, ξp, ξd) where{T}
     )
 
     # Recover dx, dy
-    copyto!(dx, kkt.krylov_solver.yₖ)
-    copyto!(dy, kkt.krylov_solver.xₖ)
+    copyto!(dx, kkt.krylov_solver.y)
+    copyto!(dy, kkt.krylov_solver.x)
 
     # TODO: iterative refinement (?)
     return nothing

--- a/test/Project.toml
+++ b/test/Project.toml
@@ -9,4 +9,4 @@ Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [compat]
 Convex = "0.14"
-Krylov = "0.7.3"
+Krylov = "0.7.7"


### PR DESCRIPTION
`solver.x` and `solver.y` are the solutions for all solvers now.