### PR TITLE
Restore Convex.jl's tests

### DIFF
--- a/test/Project.toml
+++ b/test/Project.toml
@@ -1,10 +1,13 @@
 [deps]
+Convex = "f65535da-76fb-5f13-bab9-19810c17039a"
 Krylov = "ba0b0d4f-ebba-5204-a429-3ac8c609bfb7"
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
 MathOptInterface = "b8f27783-ece8-5eb3-8dc8-9495eed66fee"
 SparseArrays = "2f01184e-e22b-5df5-ae63-d93ebab69eaf"
 TOML = "fa267f1f-6049-4f14-aa54-33bafae1ed76"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
+Tulip = "6dd1b50a-3aae-11e9-10b5-ef983d2400fa"
 
 [compat]
+Convex = "0.14"
 Krylov = "0.7.7"

--- a/test/Project.toml
+++ b/test/Project.toml
@@ -6,7 +6,6 @@ MathOptInterface = "b8f27783-ece8-5eb3-8dc8-9495eed66fee"
 SparseArrays = "2f01184e-e22b-5df5-ae63-d93ebab69eaf"
 TOML = "fa267f1f-6049-4f14-aa54-33bafae1ed76"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
-Tulip = "6dd1b50a-3aae-11e9-10b5-ef983d2400fa"
 
 [compat]
 Convex = "0.14"

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -12,7 +12,7 @@ const TvTYPES = [Float32, Float64, BigFloat]
 
 # Check That Tulip.version() matches what's in the Project.toml
 tlp_ver = Tulip.version()
-toml_ver = TOML.parsefile("../Project.toml")["version"]
+toml_ver = TOML.parsefile(joinpath(@__DIR__, "Project.toml"))["version"]
 @test tlp_ver == VersionNumber(toml_ver)
 
 @testset "Unit tests" begin
@@ -47,14 +47,14 @@ end
     include("Interfaces/MOI_wrapper.jl")
 end
 
-# @testset "Convex Problem Depot tests" begin
-#     for T in TvTYPES
-#         @testset "$T" begin
-#             Convex.ProblemDepot.run_tests(;  exclude=[r"mip", r"exp", r"socp", r"sdp"], T = T) do problem
-#                 Convex.solve!(problem, () -> Tulip.Optimizer{T}())
-#             end
-#         end
-#     end
-# end
+@testset "Convex Problem Depot tests" begin
+    for T in TvTYPES
+        @testset "$T" begin
+            Convex.ProblemDepot.run_tests(;  exclude=[r"mip", r"exp", r"socp", r"sdp"], T = T) do problem
+                Convex.solve!(problem, () -> Tulip.Optimizer{T}())
+            end
+        end
+    end
+end
 
 end  # Tulip tests


### PR DESCRIPTION
Convex.jl v0.14.17+ supports both MOI v0.9 and v0.10, so these can be restored. (taken out in https://github.com/ds4dm/Tulip.jl/pull/105)