### PR TITLE
performance: fuse more vectorized operations

### DIFF
--- a/src/IPM/ipmdata.jl
+++ b/src/IPM/ipmdata.jl
@@ -130,7 +130,7 @@ function IPMData(pb::ProblemData{T}, mfact::Factory) where{T}
     c0 = pb.obj0
     if !pb.objsense
         # Flip objective for maximization problem
-        c .= -c
+        c .= .-c
         c0 = -c0
     end
 


### PR DESCRIPTION
https://docs.julialang.org/en/v1.8/manual/performance-tips/#More-dots:-Fuse-vectorized-operations

I ran a benchmark with Tulip.Optimizer{MultiFloats.Float64x8}(): there was no speed improvement with this benchmark, but the reduction in allocations was significant. This would translate to less GC time in a more complex application, I guess.

State on master (ae81ed857f96f1dbe279664f8b5504621880c61e):

```
BenchmarkTools.Trial: 16 samples with 1 evaluation.
 Range (min … max):  308.254 ms … 322.011 ms  ┊ GC (min … max): 0.00% … 2.00%
 Time  (median):     309.053 ms               ┊ GC (median):    0.00%
 Time  (mean ± σ):   312.932 ms ±   6.263 ms  ┊ GC (mean ± σ):  0.64% ± 0.95%

   ▁▄▄▁                                                       █
  ▆████▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▆█ ▁
  308 ms           Histogram: frequency by time          322 ms <

 Memory estimate: 26.14 MiB, allocs estimate: 93251.
```

State after "performance: fuse more vectorized operations":

```
julia> @benchmark polynomial_passing_through_intervals!(lp, 3, xs, ys) setup=(Random.seed!(876234567876); lp = Tulip.Optimizer{Float64x8}(); xs = map(Rational{BigInt}, 0:(2^7 - 1)); ys = map(t -> map(Float64x8, t), f(sqrt, 2^7)))
BenchmarkTools.Trial: 16 samples with 1 evaluation.
 Range (min … max):  309.502 ms … 329.415 ms  ┊ GC (min … max): 0.00% … 2.20%
 Time  (median):     310.327 ms               ┊ GC (median):    0.00%
 Time  (mean ± σ):   314.849 ms ±   8.429 ms  ┊ GC (mean ± σ):  0.60% ± 1.02%

  █▄█                                                       ▁ ▁
  ███▁▁▆▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁█▁█ ▁
  310 ms           Histogram: frequency by time          329 ms <

 Memory estimate: 21.71 MiB, allocs estimate: 92692.
```