### PR TITLE
Update README.md for JuMP documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,50 +1,41 @@
 # Tulip
 
 [![DOI](https://zenodo.org/badge/131298750.svg)](https://zenodo.org/badge/latestdoi/131298750)
+[![](https://github.com/ds4dm/Tulip.jl/workflows/CI/badge.svg?branch=master)](https://github.com/ds4dm/Tulip.jl/actions?query=workflow%3ACI)
+[![](https://codecov.io/github/ds4dm/Tulip.jl/coverage.svg?branch=master)](https://codecov.io/github/ds4dm/Tulip.jl?branch=master)
 
- **Documentation** | **Build Status** | **Coverage** |
-|:-----------------:|:----------------:|:------------:|
-| [![Docs][docs-stable-img]][docs-stable-url] [![Docs-dev][docs-dev-img]][docs-dev-url] | [![Build][build-img]][build-url]  | [![Codecov][codecov-img]][codecov-url] |
-
-[docs-stable-img]: https://img.shields.io/badge/docs-stable-blue.svg
-[docs-dev-img]: https://img.shields.io/badge/docs-dev-purple.svg
-[docs-stable-url]: https://ds4dm.github.io/Tulip.jl/stable
-[docs-dev-url]: https://ds4dm.github.io/Tulip.jl/dev/
-
-[build-img]: https://github.com/ds4dm/Tulip.jl/workflows/CI/badge.svg?branch=master
-[build-url]: https://github.com/ds4dm/Tulip.jl/actions?query=workflow%3ACI
-[codecov-img]: https://codecov.io/github/ds4dm/Tulip.jl/coverage.svg?branch=master
-[codecov-url]: https://codecov.io/github/ds4dm/Tulip.jl?branch=master
-
-
-## Overview
-Tulip is an open-source interior-point solver for linear optimization, written in pure Julia.
+[Tulip](https://github.com/ds4dm/Tulip.jl) is an open-source interior-point solver for linear optimization, written in pure Julia.
 It implements the homogeneous primal-dual interior-point algorithm with multiple centrality corrections, and therefore handles unbounded and infeasible problems.
 Tulip’s main feature is that its algorithmic framework is disentangled from linear algebra implementations.
 This allows to seamlessly integrate specialized routines for structured problems.
 
+## License
+
+Tulip is licensed under the [MPL 2.0 license](https://github.com/ds4dm/Tulip.jl/blob/master/LICENSE.md).
+
 ## Installation
 
-Just install like any Julia package
+Install Tulip using the Julia package manager:
 
 ```julia
-] add Tulip
+import Pkg
+Pkg.add("Tulip")
 ```
 
 ## Usage
 
-The recommended way of using Tulip is through [JuMP](https://github.com/jump-dev/JuMP.jl) and/or [MathOptInterface](https://github.com/jump-dev/MathOptInterface.jl) (MOI).
+The recommended way of using Tulip is through [JuMP](https://github.com/jump-dev/JuMP.jl) or [MathOptInterface](https://github.com/jump-dev/MathOptInterface.jl) (MOI).
 
 The low-level interface is still under development and is likely change in the future.
 The MOI interface is more stable.
 
 ### Using with JuMP
+
 Tulip follows the syntax convention `PackageName.Optimizer`:
 
 ```julia
 using JuMP
 import Tulip
-
 model = Model(Tulip.Optimizer)
 ```
 
@@ -52,15 +43,13 @@ Linear objectives, linear constraints and lower/upper bounds on variables are su
 
 ### Using with MOI
 
-The type `Tulip.Optimizer` is parametrized by the model's arithmetic, e.g., `Float64` or `BigFloat`.
+The type `Tulip.Optimizer` is parametrized by the model's arithmetic, for example, `Float64` or `BigFloat`.
 This allows to solve problem in higher numerical precision.
 See the documentation for more details.
 
 ```julia
-import MathOptInterface
-MOI = MathOptInterface
+import MathOptInterface as MOI
 import Tulip
-
 model = Tulip.Optimizer{Float64}()   # Create a model in Float64 precision
 model = Tulip.Optimizer()            # Defaults to the above call
 model = Tulip.Optimizer{BigFloat}()  # Create a model in BigFloat precision
@@ -70,7 +59,7 @@ model = Tulip.Optimizer{BigFloat}()  # Create a model in BigFloat precision
 
 ### Setting parameters
 
-When using Tulip through JuMP/MOI, parameters can be set either through MOI's generic `OptimizerAttribute`s, e.g., `MOI.TimeLimitSec` and `MOI.Silent`, or by name.
+When using Tulip through JuMP/MOI, parameters can be set either through MOI's generic `OptimizerAttribute`s, for example, `MOI.TimeLimitSec` and `MOI.Silent`, or by name.
 
 * Through JuMP
     ```julia
@@ -99,7 +88,7 @@ See the [documentation](https://ds4dm.github.io/Tulip.jl/stable/reference/option
 
 ## Command-line executable
 
-See [app building instructions](app/README.md).
+See [app building instructions](https://github.com/ds4dm/Tulip.jl/blob/master/app/README.md).
 
 ## Citing `Tulip.jl`
 


### PR DESCRIPTION
I'm adding Tulip to the JuMP documentation: https://github.com/jump-dev/JuMP.jl/pull/3360

Here's what it currently looks like: https://jump.dev/JuMP.jl/previews/PR3360/packages/Tulip/

This PR is just a few fixes to convert the GitHub markdown into something that Documenter supports.