### PR TITLE
Prep for v0.9.7

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "Tulip"
 uuid = "6dd1b50a-3aae-11e9-10b5-ef983d2400fa"
 authors = ["Mathieu Tanneau <mathieu.tanneau@gmail.com>"]
-version = "0.10.0"
+version = "0.9.7"
 
 [deps]
 CodecBzip2 = "523fee87-0ab8-5b00-afb7-3ecf72e48cfd"


### PR DESCRIPTION
Version v0.10.0 was never actually released https://github.com/JuliaRegistries/General/pull/122097 because it was tagged as a breaking release without a list of the breaking changes: https://github.com/ds4dm/Tulip.jl/commit/438a77b7e08b9233365603c1089cf4002e3f507c#commitcomment-150774778

I don't see anything actually breaking https://github.com/ds4dm/Tulip.jl/compare/v0.9.6...master so I think you can actually release v0.9.7