### PR TITLE
set verbose by default in MOI interface

### DIFF
--- a/src/Interfaces/MOI/MOI_wrapper.jl
+++ b/src/Interfaces/MOI/MOI_wrapper.jl
@@ -121,6 +121,7 @@ mutable struct Optimizer{T} <: MOI.AbstractOptimizer
             0.0
         )
 
+        set_parameter(m.inner, "OutputLevel", 1)
         for (k, v) in kwargs
             set_parameter(m.inner, string(k), v)
         end


### PR DESCRIPTION
Tulip is set to be silent by default, which is fine, but it conflicts with the design of MathOptInterface, which requires solvers to be verbose by default. The problem this causes is that MathOptInterface via generic functions can only silence solvers, not make them verbose.

This PR makes Tulip verbose in the MOI interface only, to make it conveniently controllable in generic code.